### PR TITLE
[ROUND9] 실시간 랭킹 파이프라인을 구축

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -1,10 +1,13 @@
 package com.loopers.application.catalog.product;
 
+import com.loopers.domain.RootMeticsMessage;
+import com.loopers.domain.ViewMetricsMessage;
 import com.loopers.domain.catalog.product.ProductProjection;
 import com.loopers.domain.catalog.product.ProductRepository;
 import com.loopers.domain.rank.RankingRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import com.loopers.support.shared.MessageConverter;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class ProductFacade {
   private final ProductRepository productRepository;
   private final RankingRepository rankingRepository;
+  private final MessageConverter converter;
   private final ProductWarmupProcessor warmupProcessor;
   private final ProductEventPublisher publisher;
   private final ProductPublisher productPublisher;
@@ -49,7 +53,8 @@ public class ProductFacade {
     try {
       ProductProjection productProjection = productRepository.get(id);
       publisher.send(userId, userId + "가 productId : " + id + "를 조회 했습니다.");
-      productPublisher.aggregate(id);
+
+      productPublisher.aggregate(new RootMeticsMessage(new ViewMetricsMessage(id, 1)), id);
       Long rank = rankingRepository.getRank(productProjection.getId());
       return ProductGetInfo.builder()
           .productId(productProjection.getId())

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -2,6 +2,7 @@ package com.loopers.application.catalog.product;
 
 import com.loopers.domain.catalog.product.ProductProjection;
 import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.rank.RankingRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProductFacade {
   private final ProductRepository productRepository;
+  private final RankingRepository rankingRepository;
   private final ProductWarmupProcessor warmupProcessor;
   private final ProductEventPublisher publisher;
   private final ProductPublisher productPublisher;
@@ -48,8 +50,10 @@ public class ProductFacade {
       ProductProjection productProjection = productRepository.get(id);
       publisher.send(userId, userId + "가 productId : " + id + "를 조회 했습니다.");
       productPublisher.aggregate(id);
+      Long rank = rankingRepository.getRank(productProjection.getId());
       return ProductGetInfo.builder()
           .productId(productProjection.getId())
+          .rank(rank)
           .productName(productProjection.getName())
           .brandName(productProjection.getBrandName())
           .price(productProjection.getPrice())

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductGetInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductGetInfo.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record ProductGetInfo(
     Long productId,
+    Long rank,
     String brandName,
     String productName,
     BigInteger price,

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductLikeListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductLikeListener.java
@@ -1,9 +1,13 @@
 package com.loopers.application.catalog.product;
 
 import com.loopers.application.like.LikePublisher;
+import com.loopers.domain.LikeMetricsMessage;
+import com.loopers.domain.RootMessage;
+import com.loopers.domain.RootMeticsMessage;
 import com.loopers.domain.catalog.product.status.ProductStatusRepository;
 import com.loopers.domain.like.LikeDecreaseEvent;
 import com.loopers.domain.like.LikeIncreaseEvent;
+import com.loopers.support.shared.MessageConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -13,13 +17,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductLikeListener {
   private final ProductStatusRepository repository;
+  private final MessageConverter converter;
   private final LikePublisher publisher;
 
   @Async
   @EventListener
   public void increase(LikeIncreaseEvent event) {
     repository.increase(event.productId());
-    publisher.aggregate(event.productId(), 1);
+    publisher.aggregate(generate(event.productId(), 1), event.productId());
   }
 
 
@@ -27,11 +32,14 @@ public class ProductLikeListener {
   @EventListener
   public void decrease(LikeDecreaseEvent event) {
     repository.decrease(event.productId());
-    publisher.aggregate(event.productId(), -1);
-
+    publisher.aggregate(generate(event.productId(), -1), event.productId());
     if (event.current() == 0) {
       publisher.evict(event.productId());
     }
+  }
+
+  private RootMessage generate(Long productId, Integer data) {
+    return new RootMeticsMessage(new LikeMetricsMessage(productId, data));
   }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductPublisher.java
@@ -1,5 +1,7 @@
 package com.loopers.application.catalog.product;
 
+import com.loopers.domain.RootMessage;
+
 public interface ProductPublisher {
-  void aggregate(Long productId);
+  void aggregate(RootMessage message, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductStockProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductStockProcessor.java
@@ -2,6 +2,7 @@ package com.loopers.application.catalog.product;
 
 import com.loopers.domain.catalog.product.stock.StockDecreaseCommand;
 import com.loopers.domain.order.orderItem.OrderItemModel;
+import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -21,7 +22,8 @@ public class ProductStockProcessor {
     for (OrderItemModel orderItem : command.orderItems()) {
       Long productId = orderItem.getProductId();
       Long quantity = orderItem.getQuantity();
-      stockProcessor.decreaseStock(productId, quantity);
+      BigInteger unitPrice = orderItem.getUnitPrice();
+      stockProcessor.decreaseStock(productId, unitPrice, quantity);
     }
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventListener.java
@@ -31,7 +31,8 @@ public class StockEventListener {
     repository.decrease(event.productId(), event.quantity());
     //집계
 
-    Message message = new Message(converter.convert(new StockMetricsMessage(event.productId(), event.quantity())));
+    Message message = new Message(
+        converter.convert(new StockMetricsMessage(event.productId(), event.unitPrice(), event.quantity())));
 
     stockPublisher.aggregate(message, event.productId());
   }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventListener.java
@@ -1,9 +1,10 @@
 package com.loopers.application.catalog.product;
 
+import com.loopers.domain.RootMessage;
+import com.loopers.domain.RootMeticsMessage;
+import com.loopers.domain.StockMetricsMessage;
 import com.loopers.domain.catalog.product.stock.StockDecreaseEvent;
-import com.loopers.domain.catalog.product.stock.StockMetricsMessage;
 import com.loopers.domain.catalog.product.stock.StockPublisher;
-import com.loopers.support.shared.Message;
 import com.loopers.support.shared.MessageConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,8 +32,8 @@ public class StockEventListener {
     repository.decrease(event.productId(), event.quantity());
     //집계
 
-    Message message = new Message(
-        converter.convert(new StockMetricsMessage(event.productId(), event.unitPrice(), event.quantity())));
+    RootMessage message = new RootMeticsMessage(
+        new StockMetricsMessage(event.productId(), event.unitPrice(), event.quantity()));
 
     stockPublisher.aggregate(message, event.productId());
   }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockEventPublisher.java
@@ -1,5 +1,7 @@
 package com.loopers.application.catalog.product;
 
+import java.math.BigInteger;
+
 public interface StockEventPublisher {
-  void decrease(Long productId, Long quantity, Long current);
+  void decrease(Long productId, BigInteger unitPrice, Long quantity, Long current);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/StockProcessor.java
@@ -3,6 +3,7 @@ package com.loopers.application.catalog.product;
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockPublisher;
 import com.loopers.domain.catalog.product.stock.StockRepository;
+import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +16,9 @@ public class StockProcessor {
   private final StockPublisher stockPublisher;
 
   @Transactional
-  public void decreaseStock(Long productId, Long quantity) {
+  public void decreaseStock(Long productId, BigInteger unitPrice, Long quantity) {
     StockModel stockModel = stockRepository.get(productId);
-    eventPublisher.decrease(productId, quantity, stockModel.stock());
+    eventPublisher.decrease(productId, unitPrice, quantity, stockModel.stock());
     stockModel.decrease(quantity);
 
     if (stockModel.stock() == 0L) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikePublisher.java
@@ -1,6 +1,8 @@
 package com.loopers.application.like;
 
+import com.loopers.domain.RootMessage;
+
 public interface LikePublisher {
-  void aggregate(Long productId, int data);
+  void aggregate(RootMessage message, Long productId);
   void evict(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/rank/Contents.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rank/Contents.java
@@ -1,0 +1,12 @@
+package com.loopers.application.rank;
+
+public record Contents(
+    Long brandId,
+    String brandName,
+    Long productId,
+    String productName,
+    Integer todayRank,
+    Integer diff,     // 순위 변화량 (양수=상승, 음수=하락)
+    String status     // "UP", "DOWN", "SAME", "NEW"
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/rank/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rank/ProductInfo.java
@@ -1,0 +1,7 @@
+package com.loopers.application.rank;
+
+public record ProductInfo(
+    Long productId,
+    String productName
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/rank/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rank/ProductInfo.java
@@ -1,7 +1,29 @@
 package com.loopers.application.rank;
 
+import com.loopers.domain.rank.ProductWithTrend;
+import java.util.List;
+
 public record ProductInfo(
-    Long productId,
-    String productName
+    List<Contents> contents,
+    int page,
+    int size,
+    int total
 ) {
+
+  public static ProductInfo from(List<ProductWithTrend> productsWithTrend, int page, int size, int total) {
+    List<Contents> list = productsWithTrend.stream()
+        .map(p -> new Contents(
+            p.product().getBrandId(),
+            p.product().getBrandName(),
+            p.product().getId(),
+            p.product().getName(),
+            p.todayRank(),
+            p.diff(),
+            p.status()
+        ))
+        .toList();
+    return new ProductInfo(list, page, size, total);
+  }
+
 }
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/rank/RankFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rank/RankFacade.java
@@ -1,0 +1,31 @@
+package com.loopers.application.rank;
+
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.rank.RankingRepository;
+import com.loopers.interfaces.api.rank.RankV1Dto.RankCondition;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RankFacade {
+  private final RankingRepository rankingRepository;
+  private final ProductRepository productRepository;
+
+
+  public List<ProductInfo> rank(RankCondition condition) {
+    List<Long> rankingIds = rankingRepository.range(condition.start(), condition.end());
+    List<ProductInfo> products = productRepository.getIn(rankingIds)
+        .stream().map(p -> new ProductInfo(p.getId(), p.getName())).toList();
+
+    Map<Long, ProductInfo> productMap = products.stream()
+        .collect(Collectors.toMap(ProductInfo::productId, p -> p));
+
+    return rankingIds.stream()
+        .map(productMap::get)
+        .toList();
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductProjection.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductProjection.java
@@ -30,4 +30,12 @@ public class ProductProjection {
     this.description = description;
     this.likedCount = likedCount;
   }
+
+  @QueryProjection
+  public ProductProjection(Long id, Long brandId, String brandName, String name) {
+    this.id = id;
+    this.brandId = brandId;
+    this.brandName = brandName;
+    this.name = name;
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductRepository.java
@@ -12,6 +12,7 @@ public interface ProductRepository {
   ProductProjection get(Long productId);
 
   List<ProductModel> getIn(List<Long> productIds);
+  List<ProductProjection> getProductInfos(List<Long> productIds);
 
   Optional<ProductStatus> has(Long productId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockDecreaseEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockDecreaseEvent.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.catalog.product.stock;
 
+import java.math.BigInteger;
+
 public record StockDecreaseEvent(
     Long productId,
+    BigInteger unitPrice,
     Long quantity,
     Long current
 ) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockMetricsMessage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockMetricsMessage.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.catalog.product.stock;
 
+import java.math.BigInteger;
+
 public record StockMetricsMessage(
     Long productId,
+    BigInteger price,
     Long quantity
 ) {
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/StockPublisher.java
@@ -1,9 +1,9 @@
 package com.loopers.domain.catalog.product.stock;
 
-import com.loopers.support.shared.Message;
+import com.loopers.domain.RootMessage;
 
 public interface StockPublisher {
   void evict(Long productId);
   void aggregate(Long productId, Long quantity);
-  void aggregate(Message message, Long productId);
+  void aggregate(RootMessage message, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rank/ProductTrendService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rank/ProductTrendService.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.rank;
+
+import com.loopers.domain.catalog.product.ProductProjection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ProductTrendService {
+
+  public List<ProductWithTrend> calculate(List<Long> rankingIds, int page, int size, Map<Long, Integer> previousRankMap,
+                                          List<ProductProjection> models) {
+    List<ProductWithTrend> productsWithTrend = new ArrayList<>();
+    for (int i = 0; i < rankingIds.size(); i++) {
+      Long id = rankingIds.get(i);
+      int todayRank = (page * size) + (i + 1);
+      Integer yesterdayRank = previousRankMap.get(id);
+
+      String status;
+      Integer diff = null;
+
+      if (yesterdayRank != null) {
+        diff = yesterdayRank - todayRank;
+        if (diff > 0) {
+          status = "UP";
+        } else if (diff < 0) {
+          status = "DOWN";
+        } else {
+          status = "SAME";
+        }
+      } else {
+        status = "NEW";
+      }
+
+      ProductProjection model = models.stream()
+          .filter(m -> m.getId().equals(id))
+          .findFirst()
+          .orElseThrow();
+
+      productsWithTrend.add(new ProductWithTrend(model, todayRank, yesterdayRank, diff, status));
+    }
+    return productsWithTrend;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rank/ProductWithTrend.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rank/ProductWithTrend.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.rank;
+
+import com.loopers.domain.catalog.product.ProductProjection;
+
+public record ProductWithTrend(
+    ProductProjection product,
+    Integer todayRank,
+    Integer yesterdayRank,
+    Integer diff,
+    String status
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rank/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rank/RankingRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.rank;
+
+import java.util.List;
+
+public interface RankingRepository {
+  List<Long> range(int start, int end);
+  Long getRank(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rank/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rank/RankingRepository.java
@@ -1,8 +1,12 @@
 package com.loopers.domain.rank;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface RankingRepository {
-  List<Long> range(int start, int end);
+  List<Long> range(LocalDate date, int page, int size);
+
   Long getRank(Long productId);
+
+  int total(LocalDate date);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductKafkaPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductKafkaPublisher.java
@@ -1,23 +1,21 @@
 package com.loopers.infrastructure.catalog.product;
 
 import com.loopers.application.catalog.product.ProductPublisher;
-import com.loopers.support.shared.Message;
-import com.loopers.support.shared.MessageConverter;
+import com.loopers.domain.RootMessage;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class ProductKafkaPublisher implements ProductPublisher {
   private final KafkaTemplate<Object, Object> kafkaAtLeastTemplate;
-  private final MessageConverter messageConverter;
   private final static String AGGREGATE_TOPIC = "PRODUCT_VIEWS_CHANGED_V1";
 
   @Override
-  public void aggregate(Long productId) {
-    String message = messageConverter.convert(new Message(String.valueOf(productId)));
+  public void aggregate(@Payload RootMessage message, Long productId) {
     String key = LocalDate.now().toEpochDay() + ":" + productId;
     kafkaAtLeastTemplate.send(AGGREGATE_TOPIC, key, message);
   }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
@@ -126,6 +126,19 @@ public class ProductRepositoryImpl implements ProductRepository {
         .where(product.id.in(productIds))
         .fetch();
   }
+  @Override
+  public List<ProductProjection> getProductInfos(List<Long> productIds) {
+    return query.select(new QProductProjection
+            (product.id,
+            brand.id,
+            brand.name.name,
+            product.name.name))
+        .from(product)
+        .leftJoin(brand).on(product.brandId.eq(brand.id))
+        .where(product.id.in(productIds))
+        .fetch();
+  }
+
 
   @Override
   public Optional<ProductStatus> has(Long productId) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockEventCoreEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockEventCoreEventPublisher.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.catalog.product.stock;
 
 import com.loopers.application.catalog.product.StockEventPublisher;
 import com.loopers.domain.catalog.product.stock.StockDecreaseEvent;
+import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -12,7 +13,7 @@ public class StockEventCoreEventPublisher implements StockEventPublisher {
   private final ApplicationEventPublisher event;
 
   @Override
-  public void decrease(Long productId, Long quantity, Long current) {
-    event.publishEvent(new StockDecreaseEvent(productId, quantity, current));
+  public void decrease(Long productId, BigInteger unitPrice, Long quantity, Long current) {
+    event.publishEvent(new StockDecreaseEvent(productId, unitPrice, quantity, current));
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockKafkaPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockKafkaPublisher.java
@@ -1,5 +1,6 @@
 package com.loopers.infrastructure.catalog.product.stock;
 
+import com.loopers.domain.RootMessage;
 import com.loopers.domain.catalog.product.stock.StockEvictMessage;
 import com.loopers.domain.catalog.product.stock.StockPublisher;
 import com.loopers.support.shared.Message;
@@ -21,10 +22,8 @@ public class StockKafkaPublisher implements StockPublisher {
   private final static String AGGREGATE_TOPIC = "PRODUCT_STOCK_CHANGED_V1";
 
   @Override
-  public void aggregate(@Payload Message message, Long productId) {
+  public void aggregate(@Payload RootMessage message, Long productId) {
     log.info("카프카를 통해 재고정보가 전송이 되었습니다.");
-
-
     String key = LocalDate.now().toEpochDay() + ":" + productId;
     kafkaAtLeastTemplate.send(AGGREGATE_TOPIC, key, message);
   }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeKafkaEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeKafkaEventPublisher.java
@@ -1,14 +1,15 @@
 package com.loopers.infrastructure.like;
 
 import com.loopers.application.like.LikePublisher;
+import com.loopers.domain.RootMessage;
 import com.loopers.domain.like.LikeEvictMessage;
-import com.loopers.domain.like.LikeMetricsMessage;
 import com.loopers.support.shared.Message;
 import com.loopers.support.shared.MessageConverter;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -21,11 +22,10 @@ public class LikeKafkaEventPublisher implements LikePublisher {
   private final static String AGGREGATE_TOPIC = "PRODUCT_LIKE_CHANGED_V1";
   private final static String EVICT_TOPIC = "PRODUCT_LIKE_EVICT_V1";
 
-  public void aggregate(Long productId, int data) {
-    log.info(" productId: {}, data: {}", productId, data);
+  public void aggregate(@Payload RootMessage message, Long productId) {
+    log.info(" productId: {}, data: {}", productId, productId);
     String key = LocalDate.now().toEpochDay() + ":" + productId;
-    String message = converter.convert(new Message(converter.convert(new LikeMetricsMessage(productId, data))));
-    kafkaAtLeastTemplate.send(AGGREGATE_TOPIC, key, message);
+   kafkaAtLeastTemplate.send(AGGREGATE_TOPIC, key, message);
   }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rank/RedisRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rank/RedisRankingRepository.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.rank;
+
+import com.loopers.domain.rank.RankingRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRankingRepository implements RankingRepository {
+  private final static String KEY = "ranking:all:";
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Override
+  public List<Long> range(int start, int end) {
+    return Objects.requireNonNull(redisTemplate.opsForZSet().reverseRange(generateKey(), start, end))
+        .stream().map(Long::parseLong).collect(Collectors.toList());
+  }
+
+  @Override
+  public Long getRank(Long productId) {
+    return redisTemplate.opsForZSet().reverseRank(generateKey(), String.valueOf(productId));
+  }
+
+  private String generateKey() {
+    return KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+  }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rank/RedisRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rank/RedisRankingRepository.java
@@ -17,18 +17,25 @@ public class RedisRankingRepository implements RankingRepository {
   private final RedisTemplate<String, String> redisTemplate;
 
   @Override
-  public List<Long> range(int start, int end) {
-    return Objects.requireNonNull(redisTemplate.opsForZSet().reverseRange(generateKey(), start, end))
+  public List<Long> range(LocalDate date, int page, int size) {
+    long start = ((long) page * size) + page;       // start
+    long end = start + size - 1;           // end
+    return Objects.requireNonNull(redisTemplate.opsForZSet().reverseRange(generateKey(date), start, end))
         .stream().map(Long::parseLong).collect(Collectors.toList());
   }
 
   @Override
-  public Long getRank(Long productId) {
-    return redisTemplate.opsForZSet().reverseRank(generateKey(), String.valueOf(productId));
+  public int total(LocalDate date) {
+    return Objects.requireNonNull(redisTemplate.opsForZSet().zCard(generateKey(date))).intValue();
   }
 
-  private String generateKey() {
-    return KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+  @Override
+  public Long getRank(Long productId) {
+    return redisTemplate.opsForZSet().reverseRank(generateKey(LocalDate.now()), String.valueOf(productId));
+  }
+
+  private String generateKey(LocalDate date) {
+    return KEY + date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
   }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -13,10 +13,10 @@ public class ProductV1Dto {
   public static class Search {
     @Builder
     public record Response(List<Contents> contents,
-                    int page,
-                    int size,
-                    long totalElements,
-                    int totalPages) {
+                           int page,
+                           int size,
+                           long totalElements,
+                           int totalPages) {
 
       public static Response from(ProductSearchInfo search) {
 
@@ -45,16 +45,19 @@ public class ProductV1Dto {
 
   public static class Get {
     public record Response(Long productId,
-                    String brandName,
-                    String productName,
-                    BigInteger price,
-                    int likedCount,
-                    String description,
-                    ZonedDateTime createdAt,
-                    ZonedDateTime updatedAt) {
+                           Long rank,
+                           String brandName,
+                           String productName,
+                           BigInteger price,
+                           int likedCount,
+                           String description,
+                           ZonedDateTime createdAt,
+                           ZonedDateTime updatedAt) {
 
       public static Response from(ProductGetInfo productGetInfo) {
-        return new Response(productGetInfo.productId(), productGetInfo.brandName(), productGetInfo.productName(),
+        return new Response(productGetInfo.productId(),
+            productGetInfo.rank() == null ? null : productGetInfo.rank() + 1,
+            productGetInfo.brandName(), productGetInfo.productName(),
             productGetInfo.price(),
             productGetInfo.likedCount(), productGetInfo.description(), productGetInfo.createdAt(), productGetInfo.updatedAt());
       }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Controller.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.rank;
+
+import com.loopers.application.rank.RankFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.rank.RankV1Dto.RankCondition;
+import com.loopers.interfaces.api.rank.RankV1Dto.RankResponse;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rankings")
+public class RankV1Controller {
+  private final RankFacade rankFacade;
+
+
+  @GetMapping
+  public ApiResponse<RankResponse> rank(
+      @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+      @RequestParam(value = "size", required = false) Integer size,
+      @RequestParam(value = "page", required = false) Integer page
+  ) {
+    RankCondition condition = new RankCondition(date, page, size);
+    return ApiResponse.success(RankResponse.from(rankFacade.rank(condition)));
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
@@ -1,8 +1,6 @@
 package com.loopers.interfaces.api.rank;
 
 import com.loopers.application.rank.ProductInfo;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -19,9 +17,9 @@ public class RankV1Dto {
       start = start == null ? 0 : start;
       end = end == null ? 10 : end;
 
-      if (end > 20) {
-        throw new CoreException(ErrorType.CONFLICT, "사이즈는 20개를 넘어설수 없습니다.");
-      }
+//      if (end > 20) {
+//        throw new CoreException(ErrorType.CONFLICT, "사이즈는 20개를 넘어설수 없습니다.");
+//      }
     }
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
@@ -1,0 +1,43 @@
+package com.loopers.interfaces.api.rank;
+
+import com.loopers.application.rank.ProductInfo;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.time.LocalDate;
+import java.util.List;
+
+public class RankV1Dto {
+
+  public record RankCondition(
+      LocalDate date,
+      Integer start,
+      Integer end
+  ) {
+    public RankCondition {
+      // 오늘 날짜로 지정한다.
+      date = date == null ? LocalDate.now() : date;
+      start = start == null ? 0 : start;
+      end = end == null ? 10 : end;
+
+      if (end > 20) {
+        throw new CoreException(ErrorType.CONFLICT, "사이즈는 20개를 넘어설수 없습니다.");
+      }
+    }
+  }
+
+  public record RankResponse(
+      List<Contents> contents
+  ) {
+    public static RankResponse from(List<ProductInfo> rank) {
+      return new RankResponse(rank.stream().map(
+          a -> new Contents(a.productId(), a.productName())
+      ).toList());
+    }
+  }
+
+  public record Contents(
+      Long productId,
+      String productName
+  ) {
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rank/RankV1Dto.java
@@ -1,6 +1,8 @@
 package com.loopers.interfaces.api.rank;
 
 import com.loopers.application.rank.ProductInfo;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -8,34 +10,45 @@ public class RankV1Dto {
 
   public record RankCondition(
       LocalDate date,
-      Integer start,
-      Integer end
+      Integer page,
+      Integer size
   ) {
     public RankCondition {
       // 오늘 날짜로 지정한다.
       date = date == null ? LocalDate.now() : date;
-      start = start == null ? 0 : start;
-      end = end == null ? 10 : end;
+      page = page == null ? 0 : page;
+      size = size == null ? 10 : size;
 
-//      if (end > 20) {
-//        throw new CoreException(ErrorType.CONFLICT, "사이즈는 20개를 넘어설수 없습니다.");
-//      }
+      if (size > 20) {
+        throw new CoreException(ErrorType.CONFLICT, "사이즈는 20개를 넘어설수 없습니다.");
+      }
     }
   }
 
   public record RankResponse(
-      List<Contents> contents
+      List<Contents> contents,
+      int page,
+      int size,
+      int total
   ) {
-    public static RankResponse from(List<ProductInfo> rank) {
-      return new RankResponse(rank.stream().map(
-          a -> new Contents(a.productId(), a.productName())
-      ).toList());
+    public static RankResponse from(ProductInfo info) {
+      return new RankResponse(
+          info.contents().stream().map(
+              a -> new Contents(a.todayRank(), a.brandId(), a.brandName(), a.productId(), a.productName(),
+                  a.diff(), a.status())
+          ).toList(),
+          info.page(), info.size(), info.total());
     }
   }
 
   public record Contents(
+      Integer rank,
+      Long brandId,
+      String brandName,
       Long productId,
-      String productName
+      String productName,
+      Integer diff,     // 순위 변화량 (양수=상승, 음수=하락)
+      String status     // "UP", "DOWN", "SAME", "NEW"
   ) {
   }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
@@ -8,6 +8,7 @@ import com.loopers.domain.catalog.product.stock.StockRepository;
 import com.loopers.infrastructure.catalog.product.ProductJpaRepository;
 import com.loopers.infrastructure.catalog.product.stock.StockJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigInteger;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -52,7 +53,7 @@ public class OrderStockProcessorTest {
       executor.submit(() -> {
         try {
           stockProcessor.decreaseStock(
-              7L, 1L);
+              7L, BigInteger.TEN,1L);
         } catch (Exception e) {
           System.out.println("실패: " + e.getMessage());
         } finally {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsEventListener.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsEventListener.java
@@ -1,0 +1,51 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.MetricsLikesEvent;
+import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.metrics.MetricsSalesEvent;
+import com.loopers.domain.metrics.MetricsViewsEvent;
+import java.util.Map.Entry;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsEventListener {
+  private final MetricsRepository repository;
+
+  public MetricsEventListener(MetricsRepository repository) {
+    this.repository = repository;
+  }
+
+  @EventListener
+  @Async
+  public void sales(MetricsSalesEvent event) {
+    for (Entry<Long, Long> entry : event.map().entrySet()) {
+      Long productId = entry.getKey();
+      Long sum = entry.getValue();
+      repository.upsertSales(productId, sum);
+    }
+  }
+
+  @EventListener
+  @Async
+  public void views(MetricsViewsEvent event) {
+    for (Entry<Long, Long> entry : event.map().entrySet()) {
+      Long productId = entry.getKey();
+      Long sum = entry.getValue();
+      repository.upsertViews(productId, sum);
+    }
+  }
+
+  @EventListener
+  @Async
+  public void likes(MetricsLikesEvent event) {
+    for (Entry<Long, Long> entry : event.map().entrySet()) {
+      Long productId = entry.getKey();
+      Long sum = entry.getValue();
+      repository.upsertLikes(productId, sum);
+    }
+  }
+
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.groupingBy;
 
 import com.loopers.domain.LikeMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
-import com.loopers.domain.metrics.MetricsRepository;
 import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
@@ -15,14 +14,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MetricsLikesStrategy extends MetricsStrategy {
-  private final MetricsRepository repository;
+  private final MetricsPublisher publisher;
 
-  public MetricsLikesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
+  public MetricsLikesStrategy(RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MessageConvert convert, RankRepository rankRepository) {
+                              MessageConvert convert, RankRepository rankRepository, MetricsPublisher publisher) {
     super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
-    this.repository = repository;
+    this.publisher = publisher;
   }
 
 
@@ -38,13 +37,7 @@ public class MetricsLikesStrategy extends MetricsStrategy {
         .map(LikeMetricsMessage.class::cast)
         .collect(groupingBy(LikeMetricsMessage::productId, Collectors.summingLong(LikeMetricsMessage::data)));
 
-    // 파티션별로
-//    for (Entry<Long, Long> entry : map.entrySet()) {
-//      Long productId = entry.getKey();
-//      Long sum = entry.getValue();
-//      repository.upsertLikes(productId, sum);
-//    }
-
+    publisher.likes(map);
     increment(map, weight().getLikes());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -5,11 +5,11 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.LikeMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -20,11 +20,10 @@ public class MetricsLikesStrategy extends MetricsStrategy {
   public MetricsLikesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MessageConvert convert) {
-    super(rankingRepository, eventHandledRepository, weightRepository, convert);
+                              MessageConvert convert, RankRepository rankRepository) {
+    super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
     this.repository = repository;
   }
-
 
 
   @Override
@@ -40,11 +39,12 @@ public class MetricsLikesStrategy extends MetricsStrategy {
         .collect(groupingBy(LikeMetricsMessage::productId, Collectors.summingLong(LikeMetricsMessage::data)));
 
     // 파티션별로
-    for (Entry<Long, Long> entry : map.entrySet()) {
-      Long productId = entry.getKey();
-      Long sum = entry.getValue();
-      repository.upsertLikes(productId, sum);
-      increment(productId, weight().getLikes(), sum);
-    }
+//    for (Entry<Long, Long> entry : map.entrySet()) {
+//      Long productId = entry.getKey();
+//      Long sum = entry.getValue();
+//      repository.upsertLikes(productId, sum);
+//    }
+
+    increment(map, weight().getLikes());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -49,7 +49,7 @@ public class MetricsLikesStrategy extends MetricsStrategy {
     for (Entry<Long, Long> entry : map.entrySet()) {
       Long productId = entry.getKey();
       Long sum = entry.getValue();
-      repository.upsertSales(productId, sum);
+      repository.upsertLikes(productId, sum);
       increment(productId, 0.3, sum);
     }
   }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.LikeMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
@@ -15,23 +16,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class MetricsLikesStrategy extends MetricsStrategy {
   private final MetricsRepository repository;
-  private final EventHandledRepository eventHandledRepository;
-  private final MessageConvert convert;
 
   public MetricsLikesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
+                              WeightRepository weightRepository,
                               MessageConvert convert) {
-    super(rankingRepository, eventHandledRepository, convert);
+    super(rankingRepository, eventHandledRepository, weightRepository, convert);
     this.repository = repository;
-    this.eventHandledRepository = eventHandledRepository;
-    this.convert = convert;
   }
 
 
-  @Override
-  public void process(String message) {
-
-  }
 
   @Override
   public MetricsMethod method() {
@@ -50,7 +44,7 @@ public class MetricsLikesStrategy extends MetricsStrategy {
       Long productId = entry.getKey();
       Long sum = entry.getValue();
       repository.upsertLikes(productId, sum);
-      increment(productId, 0.3, sum);
+      increment(productId, weight().getLikes(), sum);
     }
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -37,7 +37,7 @@ public class MetricsLikesStrategy extends MetricsStrategy {
         .map(LikeMetricsMessage.class::cast)
         .collect(groupingBy(LikeMetricsMessage::productId, Collectors.summingLong(LikeMetricsMessage::data)));
 
-    publisher.likes(map);
+//    publisher.likes(map);
     increment(map, weight().getLikes());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -8,13 +8,15 @@ import com.loopers.support.shared.MessageConvert;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MetricsLikesStrategy implements MetricsStrategy {
+public class MetricsLikesStrategy extends MetricsStrategy {
   private final MetricsRepository repository;
   private final EventHandledRepository eventHandledRepository;
   private final MessageConvert convert;
 
-  public MetricsLikesStrategy(MetricsRepository repository, EventHandledRepository eventHandledRepository,
+  public MetricsLikesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
+                              EventHandledRepository eventHandledRepository,
                               MessageConvert convert) {
+    super(rankingRepository);
     this.repository = repository;
     this.eventHandledRepository = eventHandledRepository;
     this.convert = convert;
@@ -27,6 +29,7 @@ public class MetricsLikesStrategy implements MetricsStrategy {
     String payload = convertMessage.getPayload();
     LikeMetricsMessage result = convert.convert(payload, LikeMetricsMessage.class);
     repository.upsertLikes(result.productId(), result.data());
+    increment(result.productId(), 0.3, result.data());
     eventHandledRepository.save(convertMessage.getEventId());
   }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsLikesStrategy.java
@@ -37,7 +37,7 @@ public class MetricsLikesStrategy extends MetricsStrategy {
         .map(LikeMetricsMessage.class::cast)
         .collect(groupingBy(LikeMetricsMessage::productId, Collectors.summingLong(LikeMetricsMessage::data)));
 
-//    publisher.likes(map);
     increment(map, weight().getLikes());
+    publisher.likes(map);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsMethod.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsMethod.java
@@ -8,7 +8,7 @@ public enum MetricsMethod {
     if (topic.contains("VIEWS")) {
       return VIEWS;
     }
-    if (topic.contains("LIKES")) {
+    if (topic.contains("LIKE")) {
       return LIKES;
     }
     if (topic.contains("STOCK")) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsPublisher.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsPublisher.java
@@ -1,0 +1,30 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.MetricsLikesEvent;
+import com.loopers.domain.metrics.MetricsSalesEvent;
+import com.loopers.domain.metrics.MetricsViewsEvent;
+import java.util.Map;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsPublisher {
+  private final ApplicationEventPublisher publisher;
+
+  public MetricsPublisher(ApplicationEventPublisher publisher) {
+    this.publisher = publisher;
+  }
+
+  public void sales(Map<Long, Long> map) {
+    publisher.publishEvent(new MetricsSalesEvent(map));
+  }
+
+  public void views(Map<Long, Long> map) {
+    publisher.publishEvent(new MetricsViewsEvent(map));
+  }
+
+  public void likes(Map<Long, Long> map) {
+    publisher.publishEvent(new MetricsLikesEvent(map));
+  }
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -8,15 +8,18 @@ import com.loopers.support.shared.MessageConvert;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MetricsSalesStrategy implements MetricsStrategy {
+public class MetricsSalesStrategy extends MetricsStrategy {
   private final MessageConvert convert;
   private final EventHandledRepository eventHandledRepository;
   private final MetricsRepository repository;
 
-  public MetricsSalesStrategy(MessageConvert convert, EventHandledRepository eventHandledRepository, MetricsRepository repository) {
-    this.convert = convert;
-    this.eventHandledRepository = eventHandledRepository;
+  public MetricsSalesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
+                              EventHandledRepository eventHandledRepository,
+                              MessageConvert convert) {
+    super(rankingRepository);
     this.repository = repository;
+    this.eventHandledRepository = eventHandledRepository;
+    this.convert = convert;
   }
 
   @Override
@@ -25,6 +28,7 @@ public class MetricsSalesStrategy implements MetricsStrategy {
     SalesMetricsMessage result = convert.convert(convertMessage.getPayload(), SalesMetricsMessage.class);
     repository.upsertSales(result.productId(), result.quantity());
     eventHandledRepository.save(convertMessage.getEventId());
+    increment(result.productId(), 0.7, result.quantity());
   }
 
   @Override

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.groupingBy;
 
 import com.loopers.domain.StockMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
-import com.loopers.domain.metrics.MetricsRepository;
 import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
@@ -15,14 +14,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MetricsSalesStrategy extends MetricsStrategy {
-  private final MetricsRepository repository;
+  private final MetricsPublisher publisher;
 
-  public MetricsSalesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
+  public MetricsSalesStrategy(RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MessageConvert convert, RankRepository rankRepository) {
+                              MessageConvert convert, RankRepository rankRepository, MetricsPublisher publisher) {
     super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
-    this.repository = repository;
+    this.publisher = publisher;
   }
 
   public void sum(List<String> values) {
@@ -31,12 +30,7 @@ public class MetricsSalesStrategy extends MetricsStrategy {
         .map(StockMetricsMessage.class::cast)
         .collect(groupingBy(StockMetricsMessage::productId, Collectors.summingLong(StockMetricsMessage::quantity)));
 
-    // 파티션별로
-//    for (Entry<Long, Long> entry : map.entrySet()) {
-//      Long productId = entry.getKey();
-//      Long sum = entry.getValue();
-//      repository.upsertSales(productId, sum);
-//    }
+    publisher.sales(map);
     increment(map, weight().getSales());
   }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -1,10 +1,17 @@
 package com.loopers.application.metrics;
 
+import static java.util.stream.Collectors.groupingBy;
+
+import com.loopers.domain.StockMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
 import com.loopers.domain.metrics.SalesMetricsMessage;
 import com.loopers.support.shared.Message;
 import com.loopers.support.shared.MessageConvert;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,10 +23,25 @@ public class MetricsSalesStrategy extends MetricsStrategy {
   public MetricsSalesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
                               MessageConvert convert) {
-    super(rankingRepository);
+    super(rankingRepository, eventHandledRepository, convert);
     this.repository = repository;
     this.eventHandledRepository = eventHandledRepository;
     this.convert = convert;
+  }
+
+  public void sum(List<String> values) {
+    Map<Long, Long> map = process(values).stream()
+        .filter(StockMetricsMessage.class::isInstance)  // BaseMessage 중 StockMetricsMessage만 선택
+        .map(StockMetricsMessage.class::cast)
+        .collect(groupingBy(StockMetricsMessage::productId, Collectors.summingLong(StockMetricsMessage::quantity)));
+
+    // 파티션별로
+    for (Entry<Long, Long> entry : map.entrySet()) {
+      Long productId = entry.getKey();
+      Long sum = entry.getValue();
+      repository.upsertSales(productId, sum);
+      increment(productId, 0.7, sum);
+    }
   }
 
   @Override

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -30,7 +30,7 @@ public class MetricsSalesStrategy extends MetricsStrategy {
         .map(StockMetricsMessage.class::cast)
         .collect(groupingBy(StockMetricsMessage::productId, Collectors.summingLong(StockMetricsMessage::quantity)));
 
-    publisher.sales(map);
+//    publisher.sales(map);
     increment(map, weight().getSales());
   }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -5,8 +5,7 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.StockMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
-import com.loopers.domain.metrics.SalesMetricsMessage;
-import com.loopers.support.shared.Message;
+import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
@@ -16,17 +15,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MetricsSalesStrategy extends MetricsStrategy {
-  private final MessageConvert convert;
-  private final EventHandledRepository eventHandledRepository;
   private final MetricsRepository repository;
 
   public MetricsSalesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
+                              WeightRepository weightRepository,
                               MessageConvert convert) {
-    super(rankingRepository, eventHandledRepository, convert);
+    super(rankingRepository, eventHandledRepository, weightRepository, convert);
     this.repository = repository;
-    this.eventHandledRepository = eventHandledRepository;
-    this.convert = convert;
   }
 
   public void sum(List<String> values) {
@@ -40,18 +36,10 @@ public class MetricsSalesStrategy extends MetricsStrategy {
       Long productId = entry.getKey();
       Long sum = entry.getValue();
       repository.upsertSales(productId, sum);
-      increment(productId, 0.7, sum);
+      increment(productId, weight().getSales(), sum);
     }
   }
 
-  @Override
-  public void process(String message) {
-    Message convertMessage = convert.convert(message, Message.class);
-    SalesMetricsMessage result = convert.convert(convertMessage.getPayload(), SalesMetricsMessage.class);
-    repository.upsertSales(result.productId(), result.quantity());
-    eventHandledRepository.save(convertMessage.getEventId());
-    increment(result.productId(), 0.7, result.quantity());
-  }
 
   @Override
   public MetricsMethod method() {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -5,11 +5,11 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.StockMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -20,8 +20,8 @@ public class MetricsSalesStrategy extends MetricsStrategy {
   public MetricsSalesStrategy(MetricsRepository repository, RankingRepository rankingRepository,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MessageConvert convert) {
-    super(rankingRepository, eventHandledRepository, weightRepository, convert);
+                              MessageConvert convert, RankRepository rankRepository) {
+    super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
     this.repository = repository;
   }
 
@@ -32,12 +32,12 @@ public class MetricsSalesStrategy extends MetricsStrategy {
         .collect(groupingBy(StockMetricsMessage::productId, Collectors.summingLong(StockMetricsMessage::quantity)));
 
     // 파티션별로
-    for (Entry<Long, Long> entry : map.entrySet()) {
-      Long productId = entry.getKey();
-      Long sum = entry.getValue();
-      repository.upsertSales(productId, sum);
-      increment(productId, weight().getSales(), sum);
-    }
+//    for (Entry<Long, Long> entry : map.entrySet()) {
+//      Long productId = entry.getKey();
+//      Long sum = entry.getValue();
+//      repository.upsertSales(productId, sum);
+//    }
+    increment(map, weight().getSales());
   }
 
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsSalesStrategy.java
@@ -30,8 +30,8 @@ public class MetricsSalesStrategy extends MetricsStrategy {
         .map(StockMetricsMessage.class::cast)
         .collect(groupingBy(StockMetricsMessage::productId, Collectors.summingLong(StockMetricsMessage::quantity)));
 
-//    publisher.sales(map);
     increment(map, weight().getSales());
+    publisher.sales(map);
   }
 
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsService.java
@@ -1,7 +1,0 @@
-package com.loopers.application.metrics;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class MetricsService {
-}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
@@ -1,18 +1,38 @@
 package com.loopers.application.metrics;
 
+import com.loopers.domain.BaseMessage;
+import com.loopers.domain.RootMeticsMessage;
+import com.loopers.domain.event.EventHandledRepository;
+import com.loopers.support.shared.MessageConvert;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
 public abstract class MetricsStrategy {
   private final RankingRepository rankingRepository;
+  private final EventHandledRepository eventHandledRepository;
+  private final MessageConvert convert;
 
-  protected MetricsStrategy(RankingRepository rankingRepository) {
+  protected MetricsStrategy(RankingRepository rankingRepository, EventHandledRepository eventHandledRepository, MessageConvert convert) {
     this.rankingRepository = rankingRepository;
+    this.eventHandledRepository = eventHandledRepository;
+    this.convert = convert;
   }
 
   abstract public void process(String message);
 
   abstract MetricsMethod method();
+
+  abstract public void sum(List<String> values);
+
+  public List<BaseMessage> process(List<String> values) {
+    List<RootMeticsMessage> messages = values.stream().map(a -> convert.convert(a, RootMeticsMessage.class)).toList();
+
+    for (RootMeticsMessage message : messages) {
+      eventHandledRepository.save(message.eventId());
+    }
+    return messages.stream().map(RootMeticsMessage::payload).toList();
+  }
 
   public void increment(Long productId, double weight, long value) {
     rankingRepository.increment(productId, weight * value);

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
@@ -3,12 +3,17 @@ package com.loopers.application.metrics;
 import com.loopers.domain.BaseMessage;
 import com.loopers.domain.RootMeticsMessage;
 import com.loopers.domain.event.EventHandledRepository;
+import com.loopers.domain.rank.Rank;
+import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.Weight;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public abstract class MetricsStrategy {
@@ -16,6 +21,9 @@ public abstract class MetricsStrategy {
   private final EventHandledRepository eventHandledRepository;
   private final WeightRepository weightRepository;
   private final MessageConvert convert;
+
+
+  private final RankRepository rankRepository;
 
   @Value("${weight.views}")
   private double views;
@@ -26,11 +34,12 @@ public abstract class MetricsStrategy {
 
 
   protected MetricsStrategy(RankingRepository rankingRepository, EventHandledRepository eventHandledRepository,
-                            WeightRepository weightRepository, MessageConvert convert) {
+                            WeightRepository weightRepository, MessageConvert convert, RankRepository rankRepository) {
     this.rankingRepository = rankingRepository;
     this.eventHandledRepository = eventHandledRepository;
     this.weightRepository = weightRepository;
     this.convert = convert;
+    this.rankRepository = rankRepository;
   }
 
   abstract MetricsMethod method();
@@ -54,4 +63,23 @@ public abstract class MetricsStrategy {
   public void increment(Long productId, double weight, long value) {
     rankingRepository.increment(productId, weight * value);
   }
+
+  public void increment(Map<Long, Long> aggregate, double weight) {
+    rankingRepository.increment(aggregate, weight);
+  }
+
+  @Transactional
+  public void increment(Long productId, double value) {
+    Optional<Rank> rankOptional = rankRepository.get(productId);
+
+    if (rankOptional.isEmpty()) {
+      rankRepository.save(new Rank(productId,value));
+      return;
+    }
+
+    Rank rank = rankOptional.get();
+    rank.increase(value);
+  }
+
+
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
@@ -3,23 +3,35 @@ package com.loopers.application.metrics;
 import com.loopers.domain.BaseMessage;
 import com.loopers.domain.RootMeticsMessage;
 import com.loopers.domain.event.EventHandledRepository;
+import com.loopers.domain.weight.Weight;
+import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public abstract class MetricsStrategy {
   private final RankingRepository rankingRepository;
   private final EventHandledRepository eventHandledRepository;
+  private final WeightRepository weightRepository;
   private final MessageConvert convert;
 
-  protected MetricsStrategy(RankingRepository rankingRepository, EventHandledRepository eventHandledRepository, MessageConvert convert) {
+  @Value("${weight.views}")
+  private double views;
+  @Value("${weight.sales}")
+  private double sales;
+  @Value("${weight.likes}")
+  private double likes;
+
+
+  protected MetricsStrategy(RankingRepository rankingRepository, EventHandledRepository eventHandledRepository,
+                            WeightRepository weightRepository, MessageConvert convert) {
     this.rankingRepository = rankingRepository;
     this.eventHandledRepository = eventHandledRepository;
+    this.weightRepository = weightRepository;
     this.convert = convert;
   }
-
-  abstract public void process(String message);
 
   abstract MetricsMethod method();
 
@@ -32,6 +44,11 @@ public abstract class MetricsStrategy {
       eventHandledRepository.save(message.eventId());
     }
     return messages.stream().map(RootMeticsMessage::payload).toList();
+  }
+
+  public Weight weight() {
+    return weightRepository.get()
+        .orElse(new Weight(views, sales, likes));
   }
 
   public void increment(Long productId, double weight, long value) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsStrategy.java
@@ -1,8 +1,20 @@
 package com.loopers.application.metrics;
 
-public interface MetricsStrategy {
+import org.springframework.stereotype.Component;
 
-  void process(String message);
+@Component
+public abstract class MetricsStrategy {
+  private final RankingRepository rankingRepository;
 
-  MetricsMethod method();
+  protected MetricsStrategy(RankingRepository rankingRepository) {
+    this.rankingRepository = rankingRepository;
+  }
+
+  abstract public void process(String message);
+
+  abstract MetricsMethod method();
+
+  public void increment(Long productId, double weight, long value) {
+    rankingRepository.increment(productId, weight * value);
+  }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -8,15 +8,17 @@ import com.loopers.support.shared.MessageConvert;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MetricsViewsStrategy implements MetricsStrategy {
+public class MetricsViewsStrategy extends MetricsStrategy {
   private final MessageConvert convert;
   private final EventHandledRepository eventHandledRepository;
   private final MetricsRepository repository;
 
-  public MetricsViewsStrategy(MessageConvert convert, EventHandledRepository eventHandledRepository, MetricsRepository repository) {
-    this.convert = convert;
-    this.eventHandledRepository = eventHandledRepository;
+  public MetricsViewsStrategy(RankingRepository rankingRepository, MessageConvert convert,
+                              EventHandledRepository eventHandledRepository, MetricsRepository repository) {
+    super(rankingRepository);
     this.repository = repository;
+    this.eventHandledRepository = eventHandledRepository;
+    this.convert = convert;
   }
 
   @Override
@@ -25,6 +27,7 @@ public class MetricsViewsStrategy implements MetricsStrategy {
     ViewsMetricsMessage result = convert.convert(convertMessage.getPayload(), ViewsMetricsMessage.class);
     repository.upsertViews(result.productId(), result.value());
     eventHandledRepository.save(convertMessage.getEventId());
+    increment(result.productId(), 0.1, result.value());
   }
 
   @Override

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -37,7 +37,7 @@ public class MetricsViewsStrategy extends MetricsStrategy {
         .map(ViewMetricsMessage.class::cast)
         .collect(groupingBy(ViewMetricsMessage::productId, Collectors.summingLong(ViewMetricsMessage::data)));
 
-    publisher.views(map);
+//    publisher.views(map);
     increment(map, weight().getViews());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -46,7 +46,7 @@ public class MetricsViewsStrategy extends MetricsStrategy {
     for (Entry<Long, Long> entry : map.entrySet()) {
       Long productId = entry.getKey();
       Long sum = entry.getValue();
-      repository.upsertSales(productId, sum);
+      repository.upsertViews(productId, sum);
       increment(productId, 0.1, sum);
     }
   }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.groupingBy;
 
 import com.loopers.domain.ViewMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
-import com.loopers.domain.metrics.MetricsRepository;
 import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
@@ -15,14 +14,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MetricsViewsStrategy extends MetricsStrategy {
-  private final MetricsRepository repository;
+  private final MetricsPublisher publisher;
 
   public MetricsViewsStrategy(RankingRepository rankingRepository, MessageConvert convert,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MetricsRepository repository, RankRepository rankRepository) {
+                              RankRepository rankRepository, MetricsPublisher publisher) {
     super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
-    this.repository = repository;
+    this.publisher = publisher;
   }
 
 
@@ -38,12 +37,7 @@ public class MetricsViewsStrategy extends MetricsStrategy {
         .map(ViewMetricsMessage.class::cast)
         .collect(groupingBy(ViewMetricsMessage::productId, Collectors.summingLong(ViewMetricsMessage::data)));
 
-    // 파티션별로
-//    for (Entry<Long, Long> entry : map.entrySet()) {
-//      Long productId = entry.getKey();
-//      Long sum = entry.getValue();
-//      repository.upsertViews(productId, sum);
-//    }
+    publisher.views(map);
     increment(map, weight().getViews());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -5,11 +5,11 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.ViewMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.rank.RankRepository;
 import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -20,8 +20,8 @@ public class MetricsViewsStrategy extends MetricsStrategy {
   public MetricsViewsStrategy(RankingRepository rankingRepository, MessageConvert convert,
                               EventHandledRepository eventHandledRepository,
                               WeightRepository weightRepository,
-                              MetricsRepository repository) {
-    super(rankingRepository, eventHandledRepository, weightRepository, convert);
+                              MetricsRepository repository, RankRepository rankRepository) {
+    super(rankingRepository, eventHandledRepository, weightRepository, convert, rankRepository);
     this.repository = repository;
   }
 
@@ -39,11 +39,11 @@ public class MetricsViewsStrategy extends MetricsStrategy {
         .collect(groupingBy(ViewMetricsMessage::productId, Collectors.summingLong(ViewMetricsMessage::data)));
 
     // 파티션별로
-    for (Entry<Long, Long> entry : map.entrySet()) {
-      Long productId = entry.getKey();
-      Long sum = entry.getValue();
-      repository.upsertViews(productId, sum);
-      increment(productId, weight().getViews(), sum);
-    }
+//    for (Entry<Long, Long> entry : map.entrySet()) {
+//      Long productId = entry.getKey();
+//      Long sum = entry.getValue();
+//      repository.upsertViews(productId, sum);
+//    }
+    increment(map, weight().getViews());
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.groupingBy;
 import com.loopers.domain.ViewMetricsMessage;
 import com.loopers.domain.event.EventHandledRepository;
 import com.loopers.domain.metrics.MetricsRepository;
+import com.loopers.domain.weight.WeightRepository;
 import com.loopers.support.shared.MessageConvert;
 import java.util.List;
 import java.util.Map;
@@ -14,21 +15,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MetricsViewsStrategy extends MetricsStrategy {
-  private final MessageConvert convert;
-  private final EventHandledRepository eventHandledRepository;
   private final MetricsRepository repository;
 
   public MetricsViewsStrategy(RankingRepository rankingRepository, MessageConvert convert,
-                              EventHandledRepository eventHandledRepository, MetricsRepository repository) {
-    super(rankingRepository, eventHandledRepository, convert);
+                              EventHandledRepository eventHandledRepository,
+                              WeightRepository weightRepository,
+                              MetricsRepository repository) {
+    super(rankingRepository, eventHandledRepository, weightRepository, convert);
     this.repository = repository;
-    this.eventHandledRepository = eventHandledRepository;
-    this.convert = convert;
   }
 
-  @Override
-  public void process(String message) {
-  }
 
   @Override
   public MetricsMethod method() {
@@ -47,7 +43,7 @@ public class MetricsViewsStrategy extends MetricsStrategy {
       Long productId = entry.getKey();
       Long sum = entry.getValue();
       repository.upsertViews(productId, sum);
-      increment(productId, 0.1, sum);
+      increment(productId, weight().getViews(), sum);
     }
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsViewsStrategy.java
@@ -37,7 +37,7 @@ public class MetricsViewsStrategy extends MetricsStrategy {
         .map(ViewMetricsMessage.class::cast)
         .collect(groupingBy(ViewMetricsMessage::productId, Collectors.summingLong(ViewMetricsMessage::data)));
 
-//    publisher.views(map);
     increment(map, weight().getViews());
+    publisher.views(map);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingRepository.java
@@ -1,5 +1,8 @@
 package com.loopers.application.metrics;
 
+import java.util.Map;
+
 public interface RankingRepository {
   void increment(Long productId, Double score);
+  void increment(Map<Long, Long> aggregate, double weight);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.application.metrics;
+
+public interface RankingRepository {
+  void increment(Long productId, Double score);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/RankingService.java
@@ -1,0 +1,24 @@
+package com.loopers.application.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RankingService {
+  private final MetricsStrategyFactory factory;
+
+  public RankingService(MetricsStrategyFactory factory) {
+    this.factory = factory;
+  }
+
+  public void metics(Map<String, List<String>> collected) {
+    for (Entry<String, List<String>> entry : collected.entrySet()) {
+      String topic = entry.getKey();
+      List<String> values = entry.getValue();
+      factory.getStrategy(MetricsMethod.find(topic)).sum(values);
+    }
+
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsLikesEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsLikesEvent.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.metrics;
+
+import java.util.Map;
+
+public record MetricsLikesEvent(Map<Long, Long> map) {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsSalesEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsSalesEvent.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.metrics;
+
+import java.util.Map;
+
+public record MetricsSalesEvent(Map<Long, Long> map) {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsViewsEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsViewsEvent.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.metrics;
+
+import java.util.Map;
+
+public record MetricsViewsEvent(Map<Long, Long> map) {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/SalesMetricsMessage.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/SalesMetricsMessage.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.metrics;
 
+import java.math.BigInteger;
+
 public record SalesMetricsMessage(
     Long productId,
+    BigInteger unitPrice,
     Integer quantity
 ) {
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/rank/Rank.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/rank/Rank.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.rank;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "event_ranking")
+public class Rank extends BaseEntity {
+  private Long productId;
+  private Double score;
+
+  protected Rank() {
+  }
+
+  public Rank(Long productId, double score) {
+    this.productId = productId;
+    this.score = score;
+  }
+
+  public void increase(Double newScore) {
+    this.score += newScore;
+  }
+
+  public Long getProductId() {
+    return productId;
+  }
+
+  public Double getScore() {
+    return score;
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/rank/RankRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/rank/RankRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.rank;
+
+import java.util.Optional;
+
+public interface RankRepository {
+  Optional<Rank> get(Long productId);
+
+  void save(Rank rank);
+
+  void increment(Long productId, Double score);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/weight/Weight.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/weight/Weight.java
@@ -1,0 +1,46 @@
+package com.loopers.domain.weight;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "weight")
+public class Weight extends BaseEntity {
+  private Double views;
+  private Double sales;
+  private Double likes;
+
+  public Weight() {
+  }
+
+  public Weight(Double views, Double sales, Double likes) {
+    this.views = views;
+    this.sales = sales;
+    this.likes = likes;
+  }
+
+  public Double getViews() {
+    return views;
+  }
+
+  public void setViews(Double views) {
+    this.views = views;
+  }
+
+  public Double getSales() {
+    return sales;
+  }
+
+  public void setSales(Double sales) {
+    this.sales = sales;
+  }
+
+  public Double getLikes() {
+    return likes;
+  }
+
+  public void setLikes(Double likes) {
+    this.likes = likes;
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/weight/WeightRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/weight/WeightRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.weight;
+
+import java.util.Optional;
+
+public interface WeightRepository {
+  Optional<Weight> get();
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
@@ -4,7 +4,12 @@ import com.loopers.application.metrics.RankingRepository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,14 +19,36 @@ public class RedisRankingRepository implements RankingRepository {
 
   private final RedisTemplate<String, String> redisTemplate;
 
-  public RedisRankingRepository(RedisTemplate<String, String> rankingRedisTemplate) {
-    this.redisTemplate = rankingRedisTemplate;
+  private final StringRedisTemplate stringRedisTemplate;
+
+  public RedisRankingRepository(RedisTemplate<String, String> redisTemplate, StringRedisTemplate stringRedisTemplate) {
+    this.redisTemplate = redisTemplate;
+    this.stringRedisTemplate = stringRedisTemplate;
   }
 
   @Override
   public void increment(Long productId, Double score) {
     String newKey = KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-    redisTemplate.opsForZSet().incrementScore(newKey, String.valueOf(productId), score);
-    redisTemplate.expire(newKey, Duration.ofDays(2));
+    stringRedisTemplate.opsForZSet().incrementScore(newKey, String.valueOf(productId), score);
+    stringRedisTemplate.expire(newKey, Duration.ofDays(2));
   }
+
+  @Override
+  public void increment(Map<Long, Long> aggregate, double weight) {
+    String newKey = KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    stringRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+      StringRedisConnection redisConnection = (StringRedisConnection) connection;
+      for (Entry<Long, Long> entry : aggregate.entrySet()) {
+        Long productId = entry.getKey();
+        Long sum = entry.getValue();
+        double score = sum * weight;
+        redisConnection.zIncrBy(newKey, score, productId.toString());
+      }
+      redisConnection.expire(newKey, Duration.ofDays(2).getSeconds());
+      return null;
+    });
+
+
+  }
+
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.application.metrics.RankingRepository;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisRankingRepository implements RankingRepository {
+
+  private final static String KEY = "ranking:all:";
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public RedisRankingRepository(RedisTemplate<String, String> rankingRedisTemplate) {
+    this.redisTemplate = rankingRedisTemplate;
+  }
+
+  @Override
+  public void increment(Long productId, Double score) {
+    String newKey = KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    redisTemplate.opsForZSet().incrementScore(newKey, String.valueOf(productId), score);
+    redisTemplate.expire(newKey, Duration.ofDays(2));
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/RedisRankingRepository.java
@@ -4,9 +4,15 @@ import com.loopers.application.metrics.RankingRepository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.connection.zset.DefaultTuple;
+import org.springframework.data.redis.connection.zset.Tuple;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -36,13 +42,25 @@ public class RedisRankingRepository implements RankingRepository {
   @Override
   public void increment(Map<Long, Long> aggregate, double weight) {
     String newKey = KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    int batchSize = 100000; // 청크 크기
+    List<Entry<Long, Long>> entries = new ArrayList<>(aggregate.entrySet());
+
     stringRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
       StringRedisConnection redisConnection = (StringRedisConnection) connection;
-      for (Entry<Long, Long> entry : aggregate.entrySet()) {
-        Long productId = entry.getKey();
-        Long sum = entry.getValue();
-        double score = sum * weight;
-        redisConnection.zIncrBy(newKey, score, productId.toString());
+
+      for(int i = 0; i < entries.size(); i += batchSize) {
+        int end = Math.min(i + batchSize, entries.size());
+        List<Map.Entry<Long, Long>> batch = entries.subList(i, end);
+        Set<Tuple> tupleSet = new HashSet<>();
+
+        for (Map.Entry<Long, Long> entry : batch) {
+          Long productId = entry.getKey();
+          Long sum = entry.getValue();
+          double score = sum * weight;
+          tupleSet.add(new DefaultTuple(productId.toString().getBytes(), score));
+        }
+        // ZADD NX INCR 과 유사하게 동작시킬 수 있음
+        redisConnection.zAdd(newKey.getBytes(), tupleSet);
       }
       redisConnection.expire(newKey, Duration.ofDays(2).getSeconds());
       return null;

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/rank/RankJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/rank/RankJpaRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.rank;
+
+import com.loopers.domain.rank.Rank;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RankJpaRepository extends JpaRepository<Rank, Long> {
+  Optional<Rank> findByProductId(Long productId);
+
+  @Modifying
+  @Query("""
+      UPDATE Rank r SET r.score = r.score + :score
+      WHERE r.productId = :productId
+      """)
+  void increment(@Param("productId") Long productId, @Param("score") Double score);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/rank/RankRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/rank/RankRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.rank;
+
+import com.loopers.domain.rank.Rank;
+import com.loopers.domain.rank.RankRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RankRepositoryImpl implements RankRepository {
+  private final RankJpaRepository repository;
+
+  public RankRepositoryImpl(RankJpaRepository repository) {
+    this.repository = repository;
+  }
+
+  public Optional<Rank> get(Long productId) {
+    return repository.findByProductId(productId);
+  }
+
+  @Override
+  public void increment(Long productId, Double score) {
+    repository.increment(productId, score);
+  }
+
+
+  @Override
+  public void save(Rank rank) {
+    repository.save(rank);
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/weight/WeightJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/weight/WeightJpaRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.weight;
+
+import com.loopers.domain.weight.Weight;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface WeightJpaRepository extends JpaRepository<Weight, Long> {
+
+
+  @Query("""
+        SELECT w FROM Weight w
+        ORDER BY w.updatedAt DESC
+        """)
+  List<Weight> findBy(Pageable pageable);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/weight/WeightRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/weight/WeightRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.weight;
+
+import com.loopers.domain.weight.Weight;
+import com.loopers.domain.weight.WeightRepository;
+import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class WeightRepositoryImpl implements WeightRepository {
+  private final WeightJpaRepository repository;
+
+  public WeightRepositoryImpl(WeightJpaRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public Optional<Weight> get() {
+    Weight weight = repository.findBy(PageRequest.of(0, 1)).getFirst();
+    return Optional.of(weight);
+  }
+}

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -36,6 +36,11 @@ evict-kafka:
   stock:
     topic-name: PRODUCT_STOCK_EVICT_V1
 
+weight:
+  views: 0.1
+  likes: 0.3
+  sales: 0.7
+
 aggregate-kafka:
   group-id: AGGREGATE_GROUP_ID
   like:

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableAsync
-import java.util.TimeZone
+import java.util.*
 
 @ConfigurationPropertiesScan
 @EnableAsync

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,11 +1,6 @@
 package com.loopers.application.payment
 
-import com.loopers.domain.payment.Payment
-import com.loopers.domain.payment.PaymentEvent
-import com.loopers.domain.payment.PaymentEventPublisher
-import com.loopers.domain.payment.PaymentRelay
-import com.loopers.domain.payment.PaymentRepository
-import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.payment.*
 import com.loopers.domain.user.UserInfo
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -2,13 +2,7 @@ package com.loopers.domain.payment
 
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
-import jakarta.persistence.Index
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -3,7 +3,7 @@ package com.loopers.domain.payment
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.UUID
+import java.util.*
 
 @Component
 class TransactionKeyGenerator {

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -14,10 +14,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.servlet.resource.NoResourceFoundException
-import kotlin.collections.joinToString
-import kotlin.jvm.java
-import kotlin.text.isNotEmpty
-import kotlin.text.toRegex
 
 @RestControllerAdvice
 class ApiControllerAdvice {

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,17 +1,11 @@
 package com.loopers.interfaces.api.payment
 
 import com.loopers.application.payment.PaymentApplicationService
-import com.loopers.interfaces.api.ApiResponse
 import com.loopers.domain.user.UserInfo
+import com.loopers.interfaces.api.ApiResponse
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/payments")

--- a/docker/grafana/prometheus.yml
+++ b/docker/grafana/prometheus.yml
@@ -1,6 +1,9 @@
 global:
   scrape_interval: 5s
 
+remote_write:
+  - url: "http://localhost:9090/api/v1/write"
+
 scrape_configs:
   - job_name: 'spring-boot-app'
     metrics_path: '/actuator/prometheus'

--- a/docker/k6/payment.js
+++ b/docker/k6/payment.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
+import {check, sleep} from 'k6';
 
 // 테스트 옵션: 5명의 가상 사용자가 30초 동안 테스트를 진행
 export const options = {

--- a/docker/k6/search.js
+++ b/docker/k6/search.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
+import {check, sleep} from 'k6';
 
 // 부하 설정
 export const options = {

--- a/docker/k6/test.js
+++ b/docker/k6/test.js
@@ -1,11 +1,34 @@
 import http from 'k6/http';
-import {check, sleep} from 'k6';
+import {sleep} from 'k6';
+import {Counter, Rate, Trend} from 'k6/metrics';
 
-export const options = {
-    vus: 100, // 동시에 100명
-    iterations: 100, // 유저별 1세션
+// ---- Metrics 정의 ----
+function defineApiMetrics(name) {
+    return {
+        rps: new Counter(`${name}_requests`),
+        duration: new Trend(`${name}_duration`, true), // 응답 시간
+        errors: new Rate(`${name}_errors`),
+    };
+}
+
+const metrics = {
+    view: defineApiMetrics("api_products_view"),
+    like: defineApiMetrics("api_like_post"),
+    unlike: defineApiMetrics("api_like_delete"),
+    order: defineApiMetrics("api_orders"),
+    payment: defineApiMetrics("api_payment"),
 };
 
+export const options = {
+    vus: 100,
+    iterations: 100,
+    thresholds: {
+        "api_orders_errors": ["rate<0.05"],        // 에러율 < 5%
+        "api_orders_duration": ["p(95)<1000", "p(99)<2000"], // 응답시간 p95 < 500ms, p99 < 1s
+    },
+};
+
+// ---- 유틸 함수 ----
 function randomUserId(vu) {
     return `user-${vu}-${Math.floor(Math.random() * 100000)}`;
 }
@@ -18,47 +41,50 @@ function randomQuantity() {
     return Math.floor(Math.random() * 3) + 1; // 1~3
 }
 
+// ---- API 호출 래퍼 ----
+function trackRequest(api, fn) {
+    const res = fn();
+    metrics[api].rps.add(1);
+    metrics[api].duration.add(res.timings.duration);
+    metrics[api].errors.add(res.status >= 400);
+    return res;
+}
+
+// ---- API 시나리오 ----
 function doView(productId) {
-    const res = http.get(`http://host.docker.internal:8080/api/v1/products/${productId}`);
-    check(res, { 'view success': (r) => r.status === 200 });
+    return trackRequest("view", () =>
+        http.get(`http://localhost:8080/api/v1/products/${productId}`)
+    );
 }
 
 function doLike(userId, productId) {
-    const res = http.post(
-        `http://host.docker.internal:8080/api/v1/like/products/${productId}`,
-        null,
-        { headers: { 'X-USER-ID': userId } }
+    const res = trackRequest("like", () =>
+        http.post(`http://localhost:8080/api/v1/like/products/${productId}`, null, {
+            headers: { 'X-USER-ID': userId },
+        })
     );
-    check(res, { 'like success': (r) => r.status === 200 || r.status === 201 });
 
     if (Math.random() > 0.5) {
-        const resDel = http.del(
-            `http://host.docker.internal:8080/api/v1/like/products/${productId}`,
-            null,
-            { headers: { 'X-USER-ID': userId } }
+        trackRequest("unlike", () =>
+            http.del(`http://localhost:8080/api/v1/like/products/${productId}`, null, {
+                headers: { 'X-USER-ID': userId },
+            })
         );
-        check(resDel, { 'unlike success': (r) => r.status === 200 });
     }
+    return res;
 }
 
 function doOrder(userId, productId) {
     const orderPayload = JSON.stringify({
         address: 'address3',
-        items: [
-            { productId: productId, quantity: randomQuantity() }
-        ],
+        items: [{ productId: productId, quantity: randomQuantity() }],
         memo: '집앞에 두세요',
     });
 
-    const orderRes = http.post(
-        'http://host.docker.internal:8080/api/v1/orders',
-        orderPayload,
-        {
-            headers: {
-                'Content-Type': 'application/json',
-                'X-USER-ID': userId,
-            },
-        }
+    const orderRes = trackRequest("order", () =>
+        http.post('http://localhost:8080/api/v1/orders', orderPayload, {
+            headers: { 'Content-Type': 'application/json', 'X-USER-ID': userId },
+        })
     );
 
     if (orderRes.status === 200) {
@@ -68,37 +94,38 @@ function doOrder(userId, productId) {
         const paymentPayload = JSON.stringify({
             orderNumber: orderNumber,
             paymentMethod: 'CARD',
-            cardInfo: {
-                cardType: 'KB',
-                cardNo: '1234-1234-1234-1234',
-            },
+            cardInfo: { cardType: 'KB', cardNo: '1234-1234-1234-1234' },
             pgUserId: userId,
             payment: 2000000,
             description: '결제 충동',
         });
 
-        const payRes = http.post(
-            'http://host.docker.internal:8080/api/v1/payment',
-            paymentPayload,
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-USER-ID': userId,
-                },
-            }
+        trackRequest("payment", () =>
+            http.post('http://localhost:8080/api/v1/payment', paymentPayload, {
+                headers: { 'Content-Type': 'application/json', 'X-USER-ID': userId },
+            })
         );
-        check(payRes, { 'payment success': (r) => r.status === 200 });
     }
 }
 
 export default function () {
-    const url = 'http://host.docker.internal:8080/api/v1/products'; // 엔드포인트 주소
-    const res = http.get(url);
+    const userId = randomUserId(__VU);
 
-    // 응답 검증
-    check(res, {
-        'status is 200': (r) => r.status === 200,
-    });
+    // View: 항상 5~10회 호출
+    const viewCount = Math.floor(Math.random() * 6) + 5;
+    for (let i = 0; i < viewCount; i++) {
+        doView(randomProductId());
+        sleep(Math.random() * 0.5);
+    }
 
-    sleep(1); // 요청 간 대기 시간
+    // Like / Order: 선택적 호출
+    if (Math.random() > 0.5) {
+        doLike(userId, randomProductId());
+        sleep(Math.random() * 2);
+    }
+
+    if (Math.random() > 0.5) {
+        doOrder(userId, randomProductId());
+        sleep(Math.random() * 2);
+    }
 }

--- a/docker/k6/test.js
+++ b/docker/k6/test.js
@@ -1,11 +1,95 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 
-// 부하 설정
 export const options = {
-    vus: 10, // 동시에 실행할 가상 사용자 수
-    duration: '30s', // 테스트 시간
+    vus: 100, // 동시에 100명
+    iterations: 100, // 유저별 1세션
 };
+
+function randomUserId(vu) {
+    return `user-${vu}-${Math.floor(Math.random() * 100000)}`;
+}
+
+function randomProductId() {
+    return Math.floor(Math.random() * 100) + 1; // 1~100
+}
+
+function randomQuantity() {
+    return Math.floor(Math.random() * 3) + 1; // 1~3
+}
+
+function doView(productId) {
+    const res = http.get(`http://host.docker.internal:8080/api/v1/products/${productId}`);
+    check(res, { 'view success': (r) => r.status === 200 });
+}
+
+function doLike(userId, productId) {
+    const res = http.post(
+        `http://host.docker.internal:8080/api/v1/like/products/${productId}`,
+        null,
+        { headers: { 'X-USER-ID': userId } }
+    );
+    check(res, { 'like success': (r) => r.status === 200 || r.status === 201 });
+
+    if (Math.random() > 0.5) {
+        const resDel = http.del(
+            `http://host.docker.internal:8080/api/v1/like/products/${productId}`,
+            null,
+            { headers: { 'X-USER-ID': userId } }
+        );
+        check(resDel, { 'unlike success': (r) => r.status === 200 });
+    }
+}
+
+function doOrder(userId, productId) {
+    const orderPayload = JSON.stringify({
+        address: 'address3',
+        items: [
+            { productId: productId, quantity: randomQuantity() }
+        ],
+        memo: '집앞에 두세요',
+    });
+
+    const orderRes = http.post(
+        'http://host.docker.internal:8080/api/v1/orders',
+        orderPayload,
+        {
+            headers: {
+                'Content-Type': 'application/json',
+                'X-USER-ID': userId,
+            },
+        }
+    );
+
+    if (orderRes.status === 200) {
+        const orderData = orderRes.json().data;
+        const orderNumber = orderData.orderNumber;
+
+        const paymentPayload = JSON.stringify({
+            orderNumber: orderNumber,
+            paymentMethod: 'CARD',
+            cardInfo: {
+                cardType: 'KB',
+                cardNo: '1234-1234-1234-1234',
+            },
+            pgUserId: userId,
+            payment: 2000000,
+            description: '결제 충동',
+        });
+
+        const payRes = http.post(
+            'http://host.docker.internal:8080/api/v1/payment',
+            paymentPayload,
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-USER-ID': userId,
+                },
+            }
+        );
+        check(payRes, { 'payment success': (r) => r.status === 200 });
+    }
+}
 
 export default function () {
     const url = 'http://host.docker.internal:8080/api/v1/products'; // 엔드포인트 주소

--- a/docker/k6/test.js
+++ b/docker/k6/test.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
+import {check, sleep} from 'k6';
 
 // 부하 설정
 export const options = {

--- a/docker/monitoring-compose.yml
+++ b/docker/monitoring-compose.yml
@@ -4,6 +4,10 @@ services:
     image: prom/prometheus
     ports:
       - "9090:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-remote-write-receiver
     volumes:
       - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml
 
@@ -36,5 +40,6 @@ services:
       - K6_OUT=influxdb=http://influxdb:8086/k6
 
 volumes:
+  prometheus_data:
   influxdb:
   grafana:

--- a/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
+++ b/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
@@ -4,12 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
 public class DatabaseCleanUp implements InitializingBean {

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
@@ -1,6 +1,8 @@
 package com.loopers.config.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -16,9 +18,6 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @EnableKafka
 @Configuration

--- a/modules/kafka/src/main/java/com/loopers/domain/BaseMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/BaseMessage.java
@@ -1,0 +1,14 @@
+package com.loopers.domain;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "messageType")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = StockMetricsMessage.class, name = "STOCK_METRICS_MESSAGE"),
+    @JsonSubTypes.Type(value = LikeMetricsMessage.class, name = "LIKE_METRICS_MESSAGE"),
+    @JsonSubTypes.Type(value = ViewMetricsMessage.class, name = "VIEW_METRICS_MESSAGE")
+})
+public sealed interface BaseMessage permits StockMetricsMessage, LikeMetricsMessage, ViewMetricsMessage {
+
+}

--- a/modules/kafka/src/main/java/com/loopers/domain/LikeMetricsMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/LikeMetricsMessage.java
@@ -1,0 +1,7 @@
+package com.loopers.domain;
+
+public record LikeMetricsMessage(
+    Long productId,
+    int data
+) implements BaseMessage {
+}

--- a/modules/kafka/src/main/java/com/loopers/domain/RootMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/RootMessage.java
@@ -1,0 +1,11 @@
+package com.loopers.domain;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "root")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = RootMeticsMessage.class, name = "ROOT")
+})
+public sealed interface RootMessage permits RootMeticsMessage {
+}

--- a/modules/kafka/src/main/java/com/loopers/domain/RootMeticsMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/RootMeticsMessage.java
@@ -1,0 +1,15 @@
+package com.loopers.domain;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record RootMeticsMessage(
+    String eventId,
+    Long eventTime,
+    BaseMessage payload
+) implements RootMessage {
+
+  public RootMeticsMessage(BaseMessage payload) {
+    this(UUID.randomUUID().toString(), LocalDate.now().toEpochDay(), payload);
+  }
+}

--- a/modules/kafka/src/main/java/com/loopers/domain/StockMetricsMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/StockMetricsMessage.java
@@ -1,0 +1,10 @@
+package com.loopers.domain;
+
+import java.math.BigInteger;
+
+public record StockMetricsMessage(
+    Long productId,
+    BigInteger price,
+    Long quantity
+) implements BaseMessage {
+}

--- a/modules/kafka/src/main/java/com/loopers/domain/ViewMetricsMessage.java
+++ b/modules/kafka/src/main/java/com/loopers/domain/ViewMetricsMessage.java
@@ -1,0 +1,7 @@
+package com.loopers.domain;
+
+public record ViewMetricsMessage(
+    Long productId
+    , int data
+) implements BaseMessage {
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.loopers.config.redis;
 
 import io.lettuce.core.ReadFrom;
+import java.util.List;
+import java.util.function.Consumer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -11,9 +13,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.util.List;
-import java.util.function.Consumer;
 
 @Configuration
 @EnableConfigurationProperties(RedisProperties.class)


### PR DESCRIPTION
## 📌 Summary
1. 레디스 파이프라인을 활용하여 네트워크 접근 횟수 최소화 (#89)
2. 가중치 DB에 저장하여 유동적으로 동작하도록 유도(#88) 
3. 랭킹 API 생성(#86, #90) 
## 💬 Review Points

### 레디스 파이프라인 적용
- 처음에 컨슈머 그룹 전체에 단건처리되어 랭킹을 산정하는 부분에서 상품별로 상품의 가격을 합산하였고
그것을 레디스 파이프라인을 통해 최종적으로 결정하게 되었습니다. 
확실히 변경하니 쓰기 작업때, 발생이 되어지는 에러율은 감소가 되었다는 사실을 알게 되었습니다. 
이를 추측 하기에  네트워크 작업이 많이 발생하지 않기 때문이라 생각합니다. 레디스 파이프라인을 사용했을때, 어떤 점을 고려해서 사용하면 좋을까요? 연산이 적은 곳에서는 파이프라인보다는 일반적인 ZADD를 사용하는것이 좋다고는 생각하는데 멘토님의 의견은 어떤가요?

### 가중치 설정
- 가중치를 설정할때 RDB를 활용하여 데이터를 저장하였습니다. 왜냐하면 캐시를 사용하는것보다 수정하는것이 용이하다고 판단했기 때문에 RDB로만 사용했습니다. 읽기 작업이 빈번하게 발생하여 캐시를 사용하는 것을 고려해봤지만, 생각해보니 그 정도 지연은 딱히 상관없지 않을까 생각했습니다. 이 정도 지연은 큰 문제가 되지 않는다고 생각하여, RDB로만 가중치를 저장하였는데 어떻게 생각하시나요?

### 콜드 스타트
- 저는 콜드 스타트문제를 해결하기 위해 스케쥴링을 사용하지 않았습니다. 사용하지 않는 이유는 그냥 전날 랭킹을 보여주면 되지 않을까 생각했습니다. 그러면 항상 리스트에는 보여지기 때문에 굳이 해결할 필요는 없다고 생각하였습니다. 이 문제에 대해 멘토님의 생각은 어떤가요?


#### 질문) 랭킹과 정합성
- 랭킹에 대한 데이터가 정확하지 않아도 된다는 사실은 인지하고 있습니다. 궁금한건 랭킹 데이터에 금액과 관련된 데이터가 들어간 경우는 어떨지 고민이 되어집니다. 예를 들어, 브랜드들중에 합산 매출액에 대한 랭킹을 보여줘야 한다면, 이럴때도 데이터 몇 개는 맞지 않아도 될까요?
머릿속으로는 랭킹이라 정확하지 않아도 된다고 생각이 드는데.. 또 금액은 정확해야 할거 같고... 

## ✅ Checklist
### 📈 Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->